### PR TITLE
Fix invariant check in from_parts.

### DIFF
--- a/src/table.rs
+++ b/src/table.rs
@@ -112,7 +112,7 @@ impl<'s> SuffixTable<'s> {
     pub fn from_parts<'t, S, T>(text: S, table: T) -> SuffixTable<'s>
             where S: Into<Cow<'s, str>>, T: Into<Cow<'t, [u32]>> {
         let (text, table) = (text.into(), table.into());
-        assert_eq!(text.chars().count(), table.len());
+        assert_eq!(text.len(), table.len());
         SuffixTable {
             text: text,
             table: table.into_owned(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -161,6 +161,17 @@ fn many_exists_long() {
 }
 
 #[test]
+fn parts() {
+    let sa = sais("poëzie");
+    let sa2 = sa.clone();
+    
+    let (data, table) = sa2.into_parts();
+    let sa3 = SuffixTable::from_parts(data, table);
+
+    assert_eq!(sa, sa3);
+}
+
+#[test]
 fn query_longer() {
     let sa = sais("az");
     assert_eq!(sa.positions("mnomnomnomnomnomnomno"), &[]);


### PR DESCRIPTION
The suffix array table has the same length as the text in bytes. The
invariant check in from_parts, however, checks that the suffix array size is
the same as the number of characters.  This invariant holds when a string
only contains ASCII characters, but it fails otherwise.

Modify the check to use the length of the string in bytes.